### PR TITLE
SOLAPI PHP SDK 5.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "solapi/sdk",
   "description": "SOLAPI SDK for PHP",
-  "version": "5.1.0",
+  "version": "5.1.2",
   "type": "library",
   "license": "MIT",
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4cf8105d51db47e7f378ee1e0176a2f",
+    "content-hash": "5f14cf391de0c950d3c8d8f7af3bbe18",
     "packages": [
         {
             "name": "nyholm/psr7",

--- a/examples/send_sms_with_custom_http_client.php
+++ b/examples/send_sms_with_custom_http_client.php
@@ -1,0 +1,48 @@
+<?php
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use Nurigo\Solapi\Exceptions\MessageNotReceivedException;
+use Nurigo\Solapi\Models\Message;
+use Nurigo\Solapi\Services\SolapiMessageService;
+
+/**
+ * 커스텀 PSR-18 HTTP 클라이언트를 이용한 SMS 발송 예제
+ *
+ * SolapiMessageService 생성자의 3번째 인자로 PSR-18(Psr\Http\Client\ClientInterface) 호환 HTTP 클라이언트를 주입할 수 있습니다.
+ * 이 예제에서는 Guzzle HTTP 클라이언트를 사용합니다.
+ *
+ * 사전 설치가 필요합니다:
+ *   composer require guzzlehttp/guzzle
+ *
+ * Guzzle 외에도 PSR-18을 구현한 다른 HTTP 클라이언트를 사용할 수 있습니다:
+ *   - Symfony HttpClient (symfony/http-client + symfony/psr-http-message-bridge)
+ *   - PHP-HTTP Curl Client (php-http/curl-client)
+ */
+try {
+    // Guzzle 클라이언트 생성 (필요에 따라 옵션을 설정할 수 있습니다)
+    $httpClient = new Client([
+        'timeout' => 10,
+        'connect_timeout' => 5,
+        // 'proxy' => 'http://proxy.example.com:8080',
+        // 'verify' => '/path/to/cacert.pem',
+    ]);
+
+    // SolapiMessageService 생성 시 3번째 인자로 커스텀 HTTP 클라이언트를 전달합니다
+    $messageService = new SolapiMessageService("ENTER_YOUR_API_KEY", "ENTER_YOUR_API_SECRET", $httpClient);
+
+    $message = new Message();
+    $message->setTo("수신번호")
+        ->setFrom("계정에서 등록한 발신번호 입력")
+        ->setText("한글 45자, 영자 90자 이하 입력되면 자동으로 SMS타입의 메시지가 발송됩니다.");
+
+    $result = $messageService->send($message);
+    print_r($result);
+} catch (MessageNotReceivedException $exception) {
+    print_r($exception->getFailedMessageList());
+    print_r("----");
+    print_r($exception->getMessage());
+} catch (Exception $exception) {
+    print_r($exception->getMessage());
+}

--- a/src/Models/Request/DefaultAgent.php
+++ b/src/Models/Request/DefaultAgent.php
@@ -16,7 +16,7 @@ class DefaultAgent
 
     public function __construct()
     {
-        $this->sdkVersion = 'php/5.1.1';
+        $this->sdkVersion = 'php/5.1.2';
         $this->osPlatform = PHP_OS . " | " . phpversion();
     }
 }


### PR DESCRIPTION
## 기능 변경사항                                                                                                                                                       
  - 커스텀 PSR-18 HTTP 클라이언트를 이용한 SMS 발송 예제를 추가했습니다. (`examples/send_sms_with_custom_http_client.php`)
    - Guzzle HTTP 클라이언트를 활용한 발송 예제                                                                                                                          
    - Symfony HttpClient, PHP-HTTP Curl Client 등 PSR-18 호환 클라이언트 안내
        - 자세한 사항은 #24 를 확인 해 주세요.
