### PR TITLE
ci: release-please PR 검증을 CI 사이클 내로 통합 (solactl 패턴)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,21 +1,141 @@
 name: release-please
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["CI"]
+    branches: [master]
+    types: [completed]
 
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
 
 jobs:
   release-please:
     name: Run release-please
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      pr_head_sha: ${{ steps.pr-sha.outputs.sha }}
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get release-please PR head SHA
+        id: pr-sha
+        if: ${{ !steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          SHA=$(gh pr list \
+            --repo "$GH_REPO" \
+            --head release-please--branches--master \
+            --state open \
+            --json headRefOid \
+            --jq '.[0].headRefOid // ""')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+  unit-test-release-pr:
+    name: Unit (Release PR) / PHP ${{ matrix.php }}
+    needs: release-please
+    if: ${{ !needs.release-please.outputs.release_created && needs.release-please.outputs.pr_head_sha != '' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+    env:
+      PHP_VERSION: ${{ matrix.php }}
+      SHA: ${{ needs.release-please.outputs.pr_head_sha }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Set pending commit status
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/$REPO/statuses/$SHA" \
+            -f state=pending \
+            -f context="Unit / PHP $PHP_VERSION" \
+            -f description="Running unit tests..."
+
+      - name: Checkout release-please PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.pr_head_sha }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, mbstring
+          coverage: none
+          tools: composer:v2
+
+      - name: Determine PHPUnit constraint
+        id: phpunit
+        run: |
+          case "$PHP_VERSION" in
+            7.1|7.2) echo "constraint=^7.5" >> "$GITHUB_OUTPUT" ;;
+            *)       echo "constraint=^9.5" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Resolve Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ matrix.php }}-${{ steps.phpunit.outputs.constraint }}-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            composer-${{ matrix.php }}-${{ steps.phpunit.outputs.constraint }}-
+            composer-${{ matrix.php }}-
+
+      - name: Allow legacy PHPUnit on PHP 7.1/7.2
+        if: matrix.php == '7.1' || matrix.php == '7.2'
+        run: composer config --no-plugins audit.block-insecure false || true
+
+      - name: Pin PHPUnit constraint
+        env:
+          PHPUNIT_CONSTRAINT: ${{ steps.phpunit.outputs.constraint }}
+        run: composer require --dev --no-update --no-interaction "phpunit/phpunit:$PHPUNIT_CONSTRAINT"
+
+      - name: Install dependencies
+        env:
+          COMPOSER_NO_AUDIT: "1"
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run unit tests
+        run: composer test:unit
+
+      - name: Report success commit status
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/$REPO/statuses/$SHA" \
+            -f state=success \
+            -f context="Unit / PHP $PHP_VERSION" \
+            -f description="Unit tests passed"
+
+      - name: Report failure commit status
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/$REPO/statuses/$SHA" \
+            -f state=failure \
+            -f context="Unit / PHP $PHP_VERSION" \
+            -f description="Unit tests failed"


### PR DESCRIPTION
## Summary
- 기존 흐름(#28에서 도입): master push 시 `ci.yml`과 `release-please.yml`이 **병렬**로 돌고, release-please가 만든 PR에는 GITHUB_TOKEN 정책상 외부 CI가 **자동 트리거되지 않아** 검증이 누락되는 비대칭이 있었음
- 해결: [solapi/solactl](https://github.com/solapi/solactl/blob/main/.github/workflows/release-please.yml) 패턴을 따라 release-please를 CI 완료 후 **직렬화**하고, **같은 워크플로 내에서** release PR head를 다시 빌드·테스트해 commit status API로 PR 화면에 결과 표시

## Changes
- `release-please.yml` 트리거: `push.master` → `workflow_run["CI"]` (CI 성공 + push 이벤트일 때만 실행)
- `release-please` job에 outputs 추가: `release_created`, `tag_name`, `pr_head_sha` (open된 `release-please--branches--master` PR에서 `gh pr list`로 조회)
- `unit-test-release-pr` matrix job 신설:
  - 조건: `release_created != true && pr_head_sha != ''`
  - PHP 7.1~8.5 (ci.yml과 동일 매트릭스) 로 release PR head를 다시 unit test
  - 결과를 `repos/{repo}/statuses/{sha}` API로 commit status 등록 (context: `Unit / PHP X.Y`)
- 보안: 워크플로 인젝션 방지를 위해 셸 안의 모든 표현식을 `env:`로 분리하여 전달

## Why this matters
- release-please PR에는 외부 CI가 안 도므로 사람이 머지 안전성을 시각적으로 확인할 수 없었음
- 같은 매트릭스로 검증하므로 일반 PR과 동등한 안전성 보장
- release-please-action이 직접 만든 release(release_created=true) 케이스는 PHP 라이브러리라 binary 빌드가 없어 추가 job 불필요

## Test plan
- [ ] 이 PR이 머지되면 release-please.yml이 `ci.yml` 성공 후에만 트리거되는지 확인
- [ ] 직전 머지된 `fix: harden response mapping edge cases`(`aff1a43`)로 인해 release-please가 5.1.3 Release PR을 생성하면, `unit-test-release-pr` job이 실행되어 해당 PR 화면에 `Unit / PHP 7.1` ~ `Unit / PHP 8.5` 10개의 commit status가 표시되는지 확인
- [ ] Release PR이 머지되어 release_created=true가 되면 `unit-test-release-pr`은 skip되고 release-please-action이 v5.1.3 태그·GitHub Release만 생성하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)